### PR TITLE
fix: comment character consumption behavior

### DIFF
--- a/format.lua
+++ b/format.lua
@@ -50,7 +50,7 @@ local function string_concat(a, b)
 	elseif b and (not a) then
 		return b
 	else
-		return a .. " " .. b
+		return a .. b
 	end
 end
 
@@ -131,7 +131,7 @@ local grammar = P {
 	-- for the time being, accurate recording/reporting of indentation level (indentation level - parent indentation) is unsupported.
 	contiguous_body = (1 - S "\r\n") ^ 0,
 	subordinate_body = C(V "contiguous_body") *
-		(C(V "subordinate_indent" * V "contiguous_body") + C(V "wsp" ^ 1)) ^ 0,
+		(C(V "subordinate_indent" * V "contiguous_body") + (C(V"newline") * S"\t "^0 * #V"newline") ) ^ 0,
 	comment = element("comment", Cg(
 		                  P "#" * lpeg.Cf(V "subordinate_body", string_concat), "val")),
 	-- TODO automatically convert body to schema bytes variant

--- a/test.lua
+++ b/test.lua
@@ -342,8 +342,9 @@ end
 
 function testcomments()
 	local example = {
-		"# i am a normal comment created by a normal human\n\tand this comment is intended to be useful\n\t\tsee?\n\tall of this is on one line ",
-		"# i"
+		"1\n# list of one\n1",
+		"# i am a normal comment created by a normal human\n\tand this comment is intended to be useful\n\t\tsee?\n\n\tall of this is on one line ",
+		"# i",
 -- [[
 -- # aaaaa
 -- 	Ma'am is acceptable in a crunch, but I prefer Captain.
@@ -352,8 +353,9 @@ function testcomments()
 	}
 
 	local expected = {
-		{" i am a normal comment created by a normal human \n\tand this comment is intended to be useful \n\t\tsee? \n\tall of this is on one line "},
-		{" i"}
+		{1, " list of one", 1},
+		{" i am a normal comment created by a normal human\n\tand this comment is intended to be useful\n\t\tsee?\n\n\tall of this is on one line "},
+		{" i"},
 	}
 
     for i = 1,#example do


### PR DESCRIPTION
comments no longer unconditionally consume whitespace characters to allow intermediate empty newlines