### PR TITLE
flake: add stylua formatting check and add stylua to shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,13 +82,29 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1674781052,
-        "narHash": "sha256-nseKFXRvmZ+BDAeWQtsiad+5MnvI/M2Ak9iAWzooWBw=",
+        "lastModified": 1696604326,
+        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cc4bb87f5457ba06af9ae57ee4328a49ce674b1b",
+        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {
@@ -102,7 +118,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "luvitpkgs": "luvitpkgs",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     luvitpkgs = {
       url = "github:aiverson/luvit-nix";
       # inputs.nixpkgs.follows = "nixpkgs";
@@ -11,10 +12,11 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, luvitpkgs, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, luvitpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
         alicorn-check = file: pkgs.runCommandNoCC "alicorn-check-${file}" { } ''
           set -xeuo pipefail
           cd ${./.}
@@ -35,13 +37,18 @@
         };
         checks = {
           terms = alicorn-check "test-terms.lua";
+          formatting = pkgs.runCommandNoCC "stylua-check" { } ''
+            cd ${./.}
+            mkdir $out
+            ${pkgs.lib.getExe pkgs-unstable.stylua} . -c
+          '';
         };
         devShells = rec {
           alicorn = pkgs.mkShell {
             buildInputs = [
               luvitpkgs.packages.${system}.lit
               luvitpkgs.packages.${system}.luvit
-              pkgs.luaformatter
+              pkgs-unstable.stylua
 
               (pkgs.luajit.withPackages (ps: with ps; [ luasocket lpeg inspect luaunit ]))
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -43,11 +43,18 @@
             ${pkgs.lib.getExe pkgs-unstable.stylua} . -c
           '';
         };
+        # nix fmt's docs say this should only be for *.nix files but we're ignoring that as that's inconvenient
+        # See https://github.com/NixOS/nix/issues/9132#issuecomment-1754999829
         formatter = pkgs.writeShellApplication {
-          name = "run-stylua";
-          runtimeInputs = [ pkgs-unstable.stylua ];
+          name = "run-formatters";
+          runtimeInputs = [
+            pkgs-unstable.stylua
+            pkgs.nixpkgs-fmt
+          ];
           text = ''
-            stylua .
+            set -xeu
+            nixpkgs-fmt "$@"
+            stylua "$@"
           '';
         };
         devShells = rec {


### PR DESCRIPTION
Needed to add nixpkgs-unstable input for stylua as a recent release is required for `call_parentheses = Input` from d66e087cf24198c3d9f1daadabb233f039477974