### PR TITLE
derivers: special case pretty_print for single element to simplify common terms

### DIFF
--- a/test-derive-pretty-print.lua
+++ b/test-derive-pretty-print.lua
@@ -1,0 +1,53 @@
+local derivers = require "./derivers"
+local pretty_print = derivers.pretty_print
+local gen = require "./terms-generators"
+
+local mytype1 = gen.declare_enum("mytype1", {
+	{ "foo" },
+	{ "bar" },
+	{ "baz" },
+})
+
+local mytype2 = gen.declare_enum("mytype2", {
+	{ "truer" },
+	{ "middle", { "thing", mytype1 } },
+	{ "falser" },
+})
+
+local mytype3 = gen.declare_record("mytype3", {
+	"one",
+	mytype1,
+	"anotherone",
+	mytype2,
+})
+
+local nest1 = gen.declare_type()
+nest1:define_enum("nest", {
+	{ "n", { "a", nest1 }},
+	{ "base", {"mt3", mytype3}},
+})
+
+local mytype3butsimple = gen.declare_record("mytype3simple", {
+	"one",
+	gen.builtin_number,
+	"anotherone",
+	gen.builtin_number,
+})
+
+mytype3butsimple:derive(pretty_print)
+local x = mytype3butsimple(69, 420)
+print(x:pretty_print())
+
+for _, t in ipairs { mytype1, mytype2, mytype3, nest1 } do
+	t:derive(pretty_print)
+end
+local x2 = mytype3(mytype1.foo, mytype2.truer)
+local y2 = mytype3(mytype1.bar, mytype2.truer)
+local y3 = mytype3(mytype1.bar, mytype2.truer)
+local z2 = mytype3(mytype1.foo, mytype2.falser)
+local a2 = mytype3(mytype1.foo, mytype2.middle(mytype1.bar))
+local b2 = mytype3(mytype1.foo, mytype2.middle(mytype1.baz))
+local c2 = mytype3(mytype1.foo, mytype2.middle(mytype1.baz))
+local n = nest1.n(nest1.n(nest1.n(nest1.n(nest1.n(nest1.n(nest1.base(x2)))))))
+print(x2:pretty_print())
+print(n:pretty_print())


### PR DESCRIPTION
Before:
```
typed_let {
 expr = typed_prim_intrinsic {
  source = typed_literal {
   literal_value = value_prim {
    primitive_value = return function(a, b) return a - b end
   }
  }
 }
 body = typed_tuple_elim {
  subject = typed_application {
   f = typed_bound_variable {
    index = 1
   }
   arg = typed_prim_tuple_cons {
    elements = [typed_literal {
     literal_value = value_prim {
      primitive_value = 5
     }
    }, typed_literal {
     literal_value = value_prim {
      primitive_value = 1
     }
    }]
   }
  }
  length = 1
  body = typed_application {
   f = typed_bound_variable {
    index = 1
   }
   arg = typed_prim_tuple_cons {
    elements = [typed_bound_variable {
     index = 2
    }, typed_literal {
     literal_value = value_prim {
      primitive_value = 3
     }
    }]
   }
  }
 }
}
```

After:
```
typed_let{
 expr = typed_prim_intrinsic(typed_literal(value_prim("return function(a, b) return a - b end")))
 body = typed_tuple_elim{
  subject = typed_application{
   f = typed_bound_variable(1)
   arg = typed_prim_tuple_cons([typed_literal(value_prim(5)), typed_literal(value_prim(1))])
  }
  length = 1
  body = typed_application{
   f = typed_bound_variable(1)
   arg = typed_prim_tuple_cons([typed_bound_variable(2), typed_literal(value_prim(3))])
  }
 }
}
```