### PR TITLE
Fix for boxing qtype and debugging improvements

### DIFF
--- a/derivers.lua
+++ b/derivers.lua
@@ -160,6 +160,9 @@ local pretty_print = {
 		local idx = t.__index or {}
 		t.__index = idx
 		idx["pretty_print"] = record_pretty_printer(info)
+		if not t["__tostring"] then
+			t["__tostring"] = idx["pretty_print"]
+		end
 	end,
 	enum = function(t, info)
 		local idx = t.__index or {}
@@ -199,6 +202,9 @@ local pretty_print = {
 		local compiled, message = load(chunk, "derive-pretty_print_enum", "t")
 		assert(compiled, message)
 		idx["pretty_print"] = compiled(variant_printers)
+		if not t["__tostring"] then
+			t["__tostring"] = idx["pretty_print"]
+		end
 	end,
 }
 

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -1475,7 +1475,7 @@ function evaluate(typed_term, runtime_context)
 		local type_term = typed_term:unwrap_prim_boxed_type()
 		local type_value = evaluate(type_term, runtime_context)
 		local quantity, backing_type = type_value:unwrap_qtype()
-		return qtype(quantity, value.prim_boxed_type(backing_type))
+		return value.qtype(quantity, value.prim_boxed_type(backing_type))
 	elseif typed_term:is_prim_box() then
 		local content = typed_term:unwrap_prim_box()
 		return value.prim(evaluate(content, runtime_context))

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -835,11 +835,12 @@ function infer(
 			if not f_param_info:unwrap_param_info():unwrap_visibility():is_explicit() then
 				error("infer: nyi implicit parameters")
 			end
-			if not fitsinto(arg_type, f_param_type) then
-				print "function arg match failure"
-				print(f_param_type:pretty_print())
-				print(arg_type:pretty_print())
-				error("infer: mismatch in arg type and param type of function application")
+			local fitsinto_ok, fitsinto_err = fitsinto(arg_type, f_param_type)
+			if not fitsinto_ok then
+				print("function arg match failure")
+				print("f_param_type", f_param_type:pretty_print())
+				print("arg_type", arg_type:pretty_print())
+				error("infer: mismatch in arg type and param type of function application. fitsinto_err: " .. tostring(fitsinto_err))
 			end
 			local application_result_type =
 				apply_value(f_result_type, evaluate(arg_term, typechecking_context:get_runtime_context()))

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -338,6 +338,9 @@ local function fitsinto_record_generator(trait, t, info)
 			return true
 		end
 		if self.kind ~= other.kind then
+			print("fitsinto_fail kind check failed for self, other")
+			print(self)
+			print(other)
 			return false, fitsinto_fail("incompatible kinds: " .. self.kind .. ", " .. other.kind)
 		end
 		local ok, err

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -337,6 +337,9 @@ local function fitsinto_record_generator(trait, t, info)
 		if self == other then
 			return true
 		end
+		if self.kind ~= other.kind then
+			return false, fitsinto_fail("incompatible kinds: " .. self.kind .. ", " .. other.kind)
+		end
 		local ok, err
 		%s
 		return true

--- a/terms.lua
+++ b/terms.lua
@@ -914,6 +914,7 @@ for _, deriver in ipairs { derivers.as, derivers.pretty_print } do
 	quantity:derive(deriver)
 	visibility:derive(deriver)
 	value:derive(deriver)
+	neutral_value:derive(deriver)
 	binding:derive(deriver)
 end
 

--- a/test-derive-pretty-print.lua
+++ b/test-derive-pretty-print.lua
@@ -51,3 +51,6 @@ local c2 = mytype3(mytype1.foo, mytype2.middle(mytype1.baz))
 local n = nest1.n(nest1.n(nest1.n(nest1.n(nest1.n(nest1.n(nest1.base(x2)))))))
 print(x2:pretty_print())
 print(n:pretty_print())
+print(n)
+
+assert(tostring(n) == n:pretty_print())


### PR DESCRIPTION
Missing value. prefix for qtype in evaluator and more detailed error messages for fitsinto failing and function arg/param type mismatch

Includes cherry-pick of #43 