### PR TITLE
terms-generators: log more info when an invalid value is passed to a record constructor

### DIFF
--- a/terms-generators.lua
+++ b/terms-generators.lua
@@ -108,7 +108,8 @@ local function gen_record(self, cons, kind, params_with_types)
 				local argi = args[i]
 				-- type-check constructor arguments
 				if params_types[i].value_check(argi) ~= true then
-					p(argi)
+					p("value of parameter " .. v .. ":", argi)
+					p("expected type of parameter " .. v .. " is :", params_types[i])
 					error("wrong argument type passed to constructor " .. kind .. ", parameter '" .. v .. "'")
 				end
 				val[v] = argi


### PR DESCRIPTION
Requested earlier by @aiverson 