### PR TITLE
metalanguage: augment reducer errors with anchors

### DIFF
--- a/alicorn-expressions.lua
+++ b/alicorn-expressions.lua
@@ -399,8 +399,8 @@ local external_error_mt = {
 	__tostring = function(self)
 		local message = "Lua error occured inside primitive operative "
 			.. self.operative_name
-			.. " at "
-			.. (self.anchor and tostring(self.anchor) or "<unknown position>")
+			.. " "
+			.. (self.anchor and tostring(self.anchor) or " at unknown position")
 			.. ":\n"
 			.. tostring(self.cause)
 		return message

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -1629,7 +1629,12 @@ function evaluate(typed_term, runtime_context)
 		local content = typed_term:unwrap_prim_box()
 		return value.prim(evaluate(content, runtime_context))
 	elseif typed_term:is_prim_unbox() then
-		local ok, prim = typed_term:unwrap_prim_unbox():as_prim()
+		local unwrapped = typed_term:unwrap_prim_unbox()
+		if not unwrapped.as_prim then
+			print("unwrapped", unwrapped)
+			error "evaluate, is_prim_unbox: missing as_prim on unwrapped prim_unbox"
+		end
+		local ok, prim = unwrapped:as_prim()
 		if not ok then
 			error "evaluate, is_prim_unbox: expected a prim"
 		end

--- a/metalanguage.lua
+++ b/metalanguage.lua
@@ -68,9 +68,23 @@ end
 
 local reducer_mt = { __call = create_reducible }
 
+local function augment_error(syntax, reducer_name, ok, err_msg, ...)
+	if not ok then
+		err_msg = "error occured while parsing anchor "
+			.. tostring(syntax.anchor)
+			.. " for reducer "
+			.. reducer_name
+			.. "\n"
+			.. tostring(err_msg)
+		return false, err_msg
+	end
+	-- err_msg is the first result arg otherwise
+	return err_msg, ...
+end
+
 local function reducer(func, name)
 	local function funcwrapper(syntax, matcher)
-		return func(syntax, table.unpack(matcher.reducible))
+		return augment_error(syntax, name, xpcall(func, debug.traceback, syntax, table.unpack(matcher.reducible)))
 	end
 
 	local reducer = {

--- a/metalanguage.lua
+++ b/metalanguage.lua
@@ -77,8 +77,8 @@ local external_error_mt = {
 	__tostring = function(self)
 		local message = "Lua error raised inside reducer "
 			.. self.reducer_name
-			.. " at "
-			.. (self.anchor and tostring(self.anchor) or "<unknown position>")
+			.. " "
+			.. (self.anchor and tostring(self.anchor) or "at unknown position")
 			.. ":\n"
 			.. tostring(self.cause)
 		return message

--- a/runtest.lua
+++ b/runtest.lua
@@ -7,11 +7,12 @@ local terms = require "./terms"
 local exprs = require "./alicorn-expressions"
 local fs = require "fs"
 
-local src = fs.readFileSync("testfile.alc")
+local filename = "testfile.alc"
+local src = fs.readFileSync(filename)
 print("read code")
 print(src)
 print("parsing code")
-local code = format.read(src, "inline")
+local code = format.read(src, filename)
 -- p(code)
 
 local env = base_env.create()

--- a/testfile.alc
+++ b/testfile.alc
@@ -41,7 +41,7 @@ let prim-array-set =
 				array[index] = elem
 			end
 		:
-		prim-func-type (T : (boxed prim-type)) (arr : (array-type T)) (index : prim-number) (elem : (unbox prim-type T)) ->
+		prim-func-type (T : (boxed prim-type)) (arr : (array-type (unbox prim-type T))) (index : prim-number) (elem : (unbox prim-type T)) ->
 
 let prim-array-get = 
 	intrinsic


### PR DESCRIPTION
This is very messy right now due to the NYI for primitive operative apply failures converting them to lua errors.

https://github.com/Fundament-Software/Alicorn0/blob/e332cfb6a94242c0f41e953ff1b86965e63b03e1/alicorn-expressions.lua#L408-L415

I am not sure how to fix this.