### PR TITLE
terms-generators: better error for incorrect parameter types

### DIFF
--- a/terms-generators.lua
+++ b/terms-generators.lua
@@ -225,7 +225,11 @@ end
 ---@param lsp_type string
 ---@return Foreign self
 local function define_foreign(self, value_check, lsp_type)
-	setmetatable(self, nil)
+	setmetatable(self, {
+		__tostring = function()
+			return "terms-gen foreign " .. (lsp_type or "unknown")
+		end,
+	})
 	self.value_check = value_check
 	self.derive_info = {
 		kind = "foreign",

--- a/terms-generators.lua
+++ b/terms-generators.lua
@@ -112,7 +112,7 @@ local function gen_record(self, cons, kind, params_with_types)
 				-- type-check constructor arguments
 				if params_types[i].value_check(argi) ~= true then
 					p("value of parameter " .. v .. ":", argi)
-					p("expected type of parameter " .. v .. " is :", params_types[i])
+					print("expected type of parameter " .. v .. " is :", params_types[i])
 					error("wrong argument type passed to constructor " .. kind .. ", parameter '" .. v .. "'")
 				end
 				val[v] = argi
@@ -120,6 +120,11 @@ local function gen_record(self, cons, kind, params_with_types)
 			setmetatable(val, self)
 			return val
 		end,
+		setmetatable(self, {
+			__tostring = function()
+				return "terms-gen record " .. kind
+			end,
+		}),
 	})
 	local derive_info = {
 		kind = kind,
@@ -195,6 +200,11 @@ local function define_enum(self, name, variants)
 			}
 		end
 	end
+	setmetatable(self, {
+		__tostring = function()
+			return "terms-gen enum " .. name
+		end,
+	})
 	local derive_info = {
 		name = name,
 		variants = derive_variants,


### PR DESCRIPTION
tostring(records/enums/foreigns) from terms-generator produced types now shows a description of the type so the error for an incorrect parameter type says what type it is supposed to be instead of pretty-printing the entire term type.