### PR TITLE
Fix empty blocks

### DIFF
--- a/alicorn-expressions.lua
+++ b/alicorn-expressions.lua
@@ -1192,7 +1192,8 @@ local block = metalanguage.reducer(
 	function(syntax, args)
 		local goal, env = args:unwrap()
 		assert(goal:is_infer(), "NYI non-infer cases for block")
-		local lastval, newval
+		local lastval = inferrable_term.tuple_cons(inferrable_array())
+		local newval
 		local ok, continue = true, true
 		while ok and continue do
 			ok, continue, newval, syntax, env = syntax:match({

--- a/alicorn-utils.lua
+++ b/alicorn-utils.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+function M.numerify(...)
+	return select("#", ...), ...
+end
+
 ---@param ... any
 ---@return table
 function M.concat(...)

--- a/metalanguage.lua
+++ b/metalanguage.lua
@@ -433,16 +433,16 @@ function ConstructedSyntax:match(matchers, unmatched, extra)
 			return self.accepters[matcher.kind](self, matcher, extra)
 		elseif matcher.kind == MatcherKind.Reducible then
 			--   print("trying syntax reduction on kind", matcher.kind)
-			local res = { matcher.reducible.reduce(self, matcher) }
-			if res[1] then
+			local res = { U.numerify(matcher.reducible.reduce(self, matcher)) }
+			if res[2] then
 				--print("accepted syntax reduction")
 				if not matcher.handler then
 					print("missing handler for ", matcher.kind, debug.traceback())
 				end
-				return matcher.handler(extra, table.unpack(res, 2))
+				return matcher.handler(extra, table.unpack(res, 3, res[1] + 1))
 			end
 			--print("rejected syntax reduction")
-			lasterr = res[2]
+			lasterr = res[3]
 		end
 		-- local name = getmetatable(matcher.reducible)
 		-- print("rejected syntax kind", matcher.kind, name)


### PR DESCRIPTION
There were two bugs:
- facing an empty block, the block reducer returns a nil lastval followed by the environment. the match function rolls this into a table and then unpacks it, which dropped the environment. this is fixed by making the match function more resilient to nils.
- after that, the nil violates the contract that the block reducer returns an inferrable term. this is fixed by initializing lastval to an empty tuple_cons.