### PR TITLE
Feature/desc enum unification

### DIFF
--- a/base-env.lua
+++ b/base-env.lua
@@ -504,17 +504,9 @@ local tuplewrap_ascribed_name_inner = metalanguage.reducer(
 			return terms.inferrable_term.tuple_cons(inf_array(...))
 		end
 		local function cons(...)
-			return terms.inferrable_term.enum_cons(
-				terms.value.tuple_desc_type(terms.value.star(0, 0)),
-				terms.DescCons.cons,
-				tup_cons(...)
-			)
+			return terms.inferrable_term.enum_cons(terms.DescCons.cons, tup_cons(...))
 		end
-		local empty = terms.inferrable_term.enum_cons(
-			terms.value.tuple_desc_type(terms.value.star(0, 0)),
-			terms.DescCons.empty,
-			tup_cons()
-		)
+		local empty = terms.inferrable_term.enum_cons(terms.DescCons.empty, tup_cons())
 		local names = gen.declare_array(gen.builtin_string)()
 		local args = empty
 		local ok, name, type_val, type_env = syntax:match({

--- a/base-env.lua
+++ b/base-env.lua
@@ -341,17 +341,9 @@ local tupleof_ascribed_names_inner = metalanguage.reducer(
 			return terms.inferrable_term.tuple_cons(inf_array(...))
 		end
 		local function cons(...)
-			return terms.inferrable_term.enum_cons(
-				terms.value.tuple_desc_type(terms.value.star(0, 0)),
-				terms.DescCons.cons,
-				tup_cons(...)
-			)
+			return terms.inferrable_term.enum_cons(terms.DescCons.cons, tup_cons(...))
 		end
-		local empty = terms.inferrable_term.enum_cons(
-			terms.value.tuple_desc_type(terms.value.star(0, 0)),
-			terms.DescCons.empty,
-			tup_cons()
-		)
+		local empty = terms.inferrable_term.enum_cons(terms.DescCons.empty, tup_cons())
 		local names = gen.declare_array(gen.builtin_string)()
 
 		local ok, thread = syntax:match({

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -1977,7 +1977,6 @@ function infer(
 		local variants = string_value_map()
 		variants:set(constructor, arg_type)
 		local enum_type = value.enum_type(value.enum_desc_value(variants))
-		-- TODO: check arg_type against enum_type desc
 		return enum_type, arg_usages, typed_term.enum_cons(constructor, arg_term)
 	elseif inferrable_term:is_enum_elim() then
 		local subject, mechanism = inferrable_term:unwrap_enum_elim()

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -2211,7 +2211,7 @@ function infer(
 			typechecking_context,
 			"tuple type construction"
 		)
-		return terms.value.star(0, 0), desc_usages, terms.typed_term.tuple_type(desc_term)
+		return terms.value.star(0, 0), desc_usages, terms.typed_term.host_tuple_type(desc_term)
 	elseif inferrable_term:is_program_sequence() then
 		local first, anchor, continue = inferrable_term:unwrap_program_sequence()
 		local first_type, first_usages, first_term = infer(first, typechecking_context)

--- a/evaluator.lua
+++ b/evaluator.lua
@@ -831,6 +831,62 @@ add_comparer("value.enum_type", "value.enum_type", function(lctx, a, rctx, b)
 	typechecker_state:queue_constrain(lctx, a_desc, enum_desc_srel, rctx, b_desc, "enum type description")
 	return true
 end)
+add_comparer("value.enum_type", "value.tuple_desc_type", function(lctx, a, rctx, b)
+	local a_desc = a:unwrap_enum_type()
+	local b_univ = b:unwrap_tuple_desc_type()
+	local construction_variants = string_value_map()
+	-- The empty variant has no arguments
+	construction_variants:set(
+		terms.DescCons.empty,
+		value.tuple_type(value.enum_value(terms.DescCons.empty, value.tuple_value(value_array())))
+	)
+	-- The cons variant takes a prefix description and a next element, represented as a function from the prefix tuple to a type in the specified universe
+	construction_variants:set(
+		terms.DescCons.cons,
+		value.tuple_type(
+			value.enum_value(
+				terms.DescCons.cons,
+				value.tuple_value(
+					value_array(
+						value.enum_value(
+							terms.DescCons.cons,
+							value.tuple_value(
+								value_array(
+									value.enum_value(terms.DescCons.empty, value.tuple_value(value_array())),
+									value.closure("#prefix", typed_term.literal(b), rctx.runtime_context)
+								)
+							)
+						),
+						value.closure(
+							"#prefix",
+							typed_term.tuple_elim(
+								string_array("prefix-desc"),
+								typed_term.bound_variable(#rctx + 2),
+								1,
+								typed_term.pi(
+									typed_term.tuple_type(typed_term.bound_variable(#rctx + 3)),
+									typed.literal(value.param_info(value.visibility(terms.visibility.explicit))),
+									typed_term.bound_variable(#rctx + 1),
+									typed.literal(value.result_info(terms.result_info(terms.purity.pure)))
+								)
+							),
+							rctx.runtime_context:append(b_univ)
+						)
+					)
+				)
+			)
+		)
+	)
+	typechecker_state:queue_constrain(
+		lctx,
+		a_desc,
+		enum_desc_srel,
+		rctx,
+		value.enum_desc_value(construction_variants),
+		"use enum construction as tuple desc"
+	)
+	return true
+end)
 add_comparer("value.pi", "value.pi", function(lctx, a, rctx, b)
 	if a == b then
 		return true
@@ -1759,10 +1815,15 @@ function infer(
 	elseif inferrable_term:is_tuple_type() then
 		local desc = inferrable_term:unwrap_tuple_type()
 		local desc_type, desc_usages, desc_term = infer(desc, typechecking_context)
-		if not desc_type:is_tuple_desc_type() then
-			error "argument to tuple_type is not a tuple_desc"
-		end
-		return terms.value.star(0, 0), desc_usages, terms.typed_term.tuple_type(desc_term)
+		local univ_var = typechecker_state:metavariable(typechecking_context, false):as_value()
+		typechecker_state:flow(
+			desc_type,
+			typechecking_context,
+			value.tuple_desc_type(univ_var),
+			typechecking_context,
+			"tuple type construction"
+		)
+		return value.union_type(terms.value.star(0, 0), univ_var), desc_usages, terms.typed_term.tuple_type(desc_term)
 	elseif inferrable_term:is_record_cons() then
 		local fields = inferrable_term:unwrap_record_cons()
 		-- type_data is either "empty", an empty tuple,
@@ -1855,8 +1916,11 @@ function infer(
 		add_arrays(result_usages, body_usages)
 		return body_type, result_usages, typed_term.record_elim(subject_term, field_names, body_term)
 	elseif inferrable_term:is_enum_cons() then
-		local enum_type, constructor, arg = inferrable_term:unwrap_enum_cons()
+		local constructor, arg = inferrable_term:unwrap_enum_cons()
 		local arg_type, arg_usages, arg_term = infer(arg, typechecking_context)
+		local variants = string_value_map()
+		variants:set(constructor, arg_type)
+		local enum_type = value.enum_type(value.enum_desc_value(variants))
 		-- TODO: check arg_type against enum_type desc
 		return enum_type, arg_usages, typed_term.enum_cons(constructor, arg_term)
 	elseif inferrable_term:is_enum_elim() then
@@ -1869,6 +1933,42 @@ function infer(
 		local mechanism_type, mechanism_usages, mechanism_term = infer(mechanism, typechecking_context)
 		-- TODO: check subject desc against mechanism desc
 		error("nyi")
+	elseif inferrable_term:is_enum_case() then
+		local subject, variants, default = inferrable_term:unwrap_enum_case()
+		local subject_type, subject_usages, subject_term = infer(subject, typechecking_context)
+		local constrain_variants = string_value_map()
+		for k, v in variants:pairs() do
+			constrain_variants[k] = typechecker_state:metavariable(typechecking_context, false):as_value()
+		end
+		typechecker_state:flow(
+			subject_type,
+			typechecking_context,
+			value.enum_type(value.enum_desc_value(constrain_variants)),
+			typechecking_context,
+			"enum case matching"
+		)
+		local term_variants = string_typed_map()
+		local result_types = {}
+		for k, v in variants:pairs() do
+			local variant_type, variant_usages, variant_term =
+				infer(v, typechecking_context:append("#variant", constrain_variants:get(k), nil, nil)) --TODO improve
+			term_variants:set(k, variant_term)
+			result_types[#result_types + 1] = variant_type
+		end
+		local result_type = result_types[1]
+		for i = 2, #result_types do
+			result_type = value.union_type(result_type, result_types[i])
+		end
+		return result_type,
+			subject_usages,
+			typed_term.enum_case(
+				subject_term,
+				term_variants,
+				typed_term.enum_absurd(
+					typed_term.bound_variable(typechecking_context:len() + 1),
+					"unacceptable enum variant"
+				)
+			)
 	elseif inferrable_term:is_object_cons() then
 		local methods = inferrable_term:unwrap_object_cons()
 		local type_data = terms.empty

--- a/terms-pretty.lua
+++ b/terms-pretty.lua
@@ -366,12 +366,9 @@ end
 ---@return TupleDescFlat[]?
 ---@return integer?
 local function inferrable_tuple_type_flatten(desc, context)
-	local enum_type, constructor, arg = desc:unwrap_enum_cons()
-	local ok, universe = enum_type:as_tuple_desc_type()
-	-- TODO: what is universe?
+	local ok, constructor, arg = desc:as_enum_cons()
 	if not ok then
-		-- non-fatal, but weird
-		print("override_pretty: inferrable.tuple_type: enum_type must be tuple_desc_type")
+		return false
 	end
 	if constructor == DescCons.empty then
 		return true, {}, 0
@@ -406,7 +403,10 @@ end
 ---@return (inferrable|string)[]
 ---@return integer
 local function inferrable_tuple_type_hydraulicpress(desc)
-	local enum_type, constructor, arg = desc:unwrap_enum_cons()
+	local ok, constructor, arg = desc:as_enum_cons()
+	if not ok then
+		return { "<UNHANDLED EDGE CASE>" }, 1
+	end
 	if constructor == DescCons.empty then
 		return {}, 0
 	elseif constructor == DescCons.cons then
@@ -431,7 +431,10 @@ end
 ---@return TupleDescFlat[]?
 ---@return integer?
 local function typed_tuple_type_flatten(desc, context)
-	local constructor, arg = desc:unwrap_enum_cons()
+	local ok, constructor, arg = desc:as_enum_cons()
+	if not ok then
+		return false
+	end
 	if constructor == DescCons.empty then
 		return true, {}, 0
 	elseif constructor == DescCons.cons then
@@ -465,7 +468,10 @@ end
 ---@return (typed|string)[]
 ---@return integer
 local function typed_tuple_type_hydraulicpress(desc)
-	local constructor, arg = desc:unwrap_enum_cons()
+	local ok, constructor, arg = desc:as_enum_cons()
+	if not ok then
+		return { "<UNHANDLED EDGE CASE>" }, 1
+	end
 	if constructor == DescCons.empty then
 		return {}, 0
 	elseif constructor == DescCons.cons then

--- a/terms.lua
+++ b/terms.lua
@@ -318,7 +318,6 @@ inferrable_term:define_enum("inferrable", {
 		"body",        inferrable_term,
 	} },
 	{ "enum_cons", {
-		"enum_type",   value,
 		"constructor", gen.builtin_string,
 		"arg",         inferrable_term,
 	} },
@@ -327,6 +326,15 @@ inferrable_term:define_enum("inferrable", {
 		"mechanism", inferrable_term,
 	} },
 	{ "enum_type", { "desc", inferrable_term } },
+	{ "enum_case", {
+		"target",   inferrable_term,
+		"variants", map(gen.builtin_string, inferrable_term),
+		--"default",  inferrable_term,
+	} },
+	{ "enum_absurd", {
+		"target", inferrable_term,
+		"debug",  gen.builtin_string,
+	} },
 	{ "object_cons", { "methods", map(gen.builtin_string, inferrable_term) } },
 	{ "object_elim", {
 		"subject",   inferrable_term,

--- a/types/inferrable.lua
+++ b/types/inferrable.lua
@@ -66,9 +66,9 @@ function inferrable:unwrap_record_elim() end
 function inferrable:as_record_elim() end
 ---@return boolean
 function inferrable:is_enum_cons() end
----@return value, string, inferrable
+---@return string, inferrable
 function inferrable:unwrap_enum_cons() end
----@return boolean, value, string, inferrable
+---@return boolean, string, inferrable
 function inferrable:as_enum_cons() end
 ---@return boolean
 function inferrable:is_enum_elim() end
@@ -82,6 +82,18 @@ function inferrable:is_enum_type() end
 function inferrable:unwrap_enum_type() end
 ---@return boolean, inferrable
 function inferrable:as_enum_type() end
+---@return boolean
+function inferrable:is_enum_case() end
+---@return inferrable, MapValue
+function inferrable:unwrap_enum_case() end
+---@return boolean, inferrable, MapValue
+function inferrable:as_enum_case() end
+---@return boolean
+function inferrable:is_enum_absurd() end
+---@return inferrable, string
+function inferrable:unwrap_enum_absurd() end
+---@return boolean, inferrable, string
+function inferrable:as_enum_absurd() end
 ---@return boolean
 function inferrable:is_object_cons() end
 ---@return MapValue
@@ -245,9 +257,11 @@ function inferrable:as_program_type() end
 ---@field tuple_type fun(desc: inferrable): inferrable
 ---@field record_cons fun(fields: MapValue): inferrable
 ---@field record_elim fun(subject: inferrable, field_names: ArrayValue, body: inferrable): inferrable
----@field enum_cons fun(enum_type: value, constructor: string, arg: inferrable): inferrable
+---@field enum_cons fun(constructor: string, arg: inferrable): inferrable
 ---@field enum_elim fun(subject: inferrable, mechanism: inferrable): inferrable
 ---@field enum_type fun(desc: inferrable): inferrable
+---@field enum_case fun(target: inferrable, variants: MapValue): inferrable
+---@field enum_absurd fun(target: inferrable, debug: string): inferrable
 ---@field object_cons fun(methods: MapValue): inferrable
 ---@field object_elim fun(subject: inferrable, mechanism: inferrable): inferrable
 ---@field let fun(name: string, expr: inferrable, body: inferrable): inferrable


### PR DESCRIPTION
This changes enum construction to be properly inferred and adds the subtyping rules required to convert them to and from tuple descs at all finite universes.