### PR TITLE
Fix left call right call

### DIFF
--- a/evaluator.lua
+++ b/evaluator.lua
@@ -4100,36 +4100,6 @@ function TypeCheckerState:constrain(val, val_context, use, use_context, rel, cau
 		end
 	end
 
-	-- for _, v in ipairs(self.graph.leftcall_edges:all()) do
-	-- 	if self.values[v.left][1] == value.host_string_type or self.values[v.right][1] == value.host_string_type then
-	-- 		print("LEFTCALL LEFT: " .. tostring(self.values[v.left][1]))
-	-- 		print("LEFTCALL RIGHT: " .. tostring(self.values[v.right][1]))
-	-- 		print("LEFTCALL ARG: " .. tostring(v.arg))
-
-	-- 		for _, c in ipairs(self.graph.constrain_edges:all()) do
-	-- 			if c.left == v.left or c.right == v.left then
-	-- 				print("CONSTRAIN MV LEFT: " .. tostring(c.left))
-	-- 				print("CONSTRAIN MV RIGHT: " .. tostring(c.right))
-	-- 			end
-	-- 		end
-
-	-- 		for _, c in ipairs(self.graph.rightcall_edges:all()) do
-	-- 			if c.left == v.left or c.right == v.left then
-	-- 				print("RIGHTCALL MV LEFT: " .. tostring(self.values[c.left][1]))
-	-- 				print("RIGHTCALL MV RIGHT: " .. tostring(self.values[c.right][1]))
-	-- 				print("RIGHTCALL ARG: " .. tostring(v.arg))
-	-- 			end
-	-- 		end
-	-- 	end
-	-- end
-
-	-- for _, v in ipairs(self.graph.rightcall_edges:all()) do
-	-- 	if self.values[v.left][1] == value.host_string_type or self.values[v.right][1] == value.host_string_type then
-	-- 		print("RIGHTCALL LEFT: " .. tostring(self.values[v.left][1]))
-	-- 		print("RIGHTCALL RIGHT: " .. tostring(self.values[v.right][1]))
-	-- 	end
-	-- end
-
 	--assert(self:DEBUG_VERIFY(), "VERIFICATION FAILED")
 	assert(#self.pending == 0, "pending was not drained!")
 	return true
@@ -4152,7 +4122,6 @@ function TypeCheckerState:slice_constraints_for(mv, mappings, context_len)
 
 	local constraints = array(terms.constraintelem)()
 
-	---comment
 	---@param id integer
 	---@return value
 	local function getnode(id)

--- a/tests/basic-annotated.alc
+++ b/tests/basic-annotated.alc
@@ -1,0 +1,29 @@
+let host-arith-binop = (host-func-type (a : host-number, b : host-number) -> ((c : host-number)))
+
+let omega = 9
+# FIXME: apparently variables aren't allowed here
+#let universe = type_(omega, 1)
+let universe = type_(9, 1)
+
+let implicit-unwrap = lambda_implicit (T : type_(10, 0))
+	lambda (x : wrapped(T))
+		unwrap T x
+
+
+let unwrap = implicit-unwrap
+
+let host-string-wrap          = intrinsic "return terms.value.host_string_type"    : wrapped(host-type)
+
+let host-string          = unwrap(host-string-wrap)
+
+let host-mul = (intrinsic "return function(a, b) return a * b end" : host-arith-binop)
+let mul = lambda (a : host-number, b : host-number)
+	let (c) = host-mul(a, b)
+	c
+let _*_ = mul
+
+# FIXME: this super duper should be failing
+let sqr_overcomplicated = lambda_annotated (t, x : t) : host-string
+	x * x
+
+sqr_overcomplicated(host-number, 6)


### PR DESCRIPTION
This fixes the below test case (which will be added to "should fail" once the test harness actually works) where we were not constraining the annotated return value of a lambda due to not enforcing a constraint between a left edge and a right edge.