### PR TITLE
try to improve array construction

### DIFF
--- a/testfile.alc
+++ b/testfile.alc
@@ -2173,7 +2173,7 @@ let sqr = lambda (x)
 	x * x
 sqr 6
 # FIXME: this super duper should be failing
-let sqr_overcomplicated = lambda_annotated (t, x : t) : host-string
+let sqr_overcomplicated = lambda_annotated (t : type, x : t) : host-string
 	x * x
 sqr_overcomplicated(host-number, 6)
 
@@ -2183,4 +2183,3 @@ sqr_overcomplicated(host-number, 6)
 #host-array-from-tuple(2, host-tuple-of(host-type, duplicate-tuple-desc(2, host-number))(1, 2))
 
 #main()
-


### PR DESCRIPTION
runtest.lua fails with *the same error main currently fails with*
```
Lua error raised inside reducer collect_tuple file testfile.alc, line 983 character 60:
./evaluator.lua:2980: both values are neutral, but they aren't equal: value.neutral(neutral_value.host_unwrap_stuck(neutral_value.tuple_element_access_stuck {
 subject = neutral_value.host_application_stuck {
  function = Lua function(_, ...): @./terms-generators.lua:123,
  arg = neutral_value.host_tuple_stuck {
   leading = [],
   stuck_element = neutral_value.host_wrap_stuck(neutral_value.free(free.placeholder {
    index = 114,
    debug = placeholder_debug {
     name = "U",
     start_anchor = file testfile.alc, line 982 character 45,
    },
   })),
   trailing = [],
   --end neutral_value.host_tuple_stuck
  },
  --end neutral_value.host_application_stuck
 },
 index = 1,
 --end neutral_value.tuple_element_access_stuck
})) ~= value.neutral(neutral_value.host_unwrap_stuc
```