### PR TITLE
nix-flake-check: remove magic nix cache

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -13,5 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix flake check


### PR DESCRIPTION
GitHub removed the caching API it relies on. There's a successor but it's not free. Not caching for now is acceptable and that's what was happening already.