### PR TITLE
flake: add reuse-lint flake check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,10 @@
             mkdir $out
             ${pkgs.lib.getExe pkgs.stylua} . -c
           '';
+          reuse-lint = pkgs.runCommandNoCCLocal "reuse-lint" { } ''
+            cd ${./.}
+            ${lib.getExe pkgs.reuse} lint && mkdir $out
+          '';
           pre-commit-check = pre-commit-hooks-lib.run {
             src = ./.;
             hooks = {


### PR DESCRIPTION
Check runs reuse lint on the src dir and fails if it finds any issues.

Assuming reuse is sticking around it'd be good to check compliance in CI.