### PR TITLE
Unglue debuginfo

### DIFF
--- a/alicorn-expressions.lua
+++ b/alicorn-expressions.lua
@@ -1231,12 +1231,14 @@ end
 ---@param name string
 ---@return anchored_inferrable
 local function host_operative(fn, name)
-	local debuginfo = debug.getinfo(fn)
-	local debugstring = (name or error("name not passed to host_operative"))
-		.. " "
-		.. debuginfo.short_src
-		.. ":"
-		.. debuginfo.linedefined
+	local short_src = "<no debug info>"
+	local linedef = 0
+	if debug then
+		local debuginfo = debug.getinfo(fn)
+		short_src = debuginfo.short_src
+		linedef = debuginfo.linedefined
+	end
+	local debugstring = (name or error("name not passed to host_operative")) .. " " .. short_src .. ":" .. linedef
 	local aborting_fn = function(syn, env, userdata, goal)
 		if not env or not env.exit_block then
 			error("env passed to host_operative " .. debugstring .. " isn't an env or is nil", env)
@@ -1263,8 +1265,8 @@ local function host_operative(fn, name)
 				"env returned from fn passed to alicorn-expressions.host_operative isn't an env or is nil",
 				env,
 				" in ",
-				debuginfo.short_src,
-				debuginfo.linedefined
+				short_src,
+				linedef
 			)
 			error("invalid env from host_operative fn " .. debugstring)
 		end

--- a/format.lua
+++ b/format.lua
@@ -451,8 +451,12 @@ local function anchor_here(f)
 	if type(f) ~= "function" then
 		f = (f or 1) + 1
 	end
-	local info = debug.getinfo(f, "Sl")
-	return create_anchor(true, "SYNTH:" .. info.source, info.currentline, 0)
+	if debug then
+		local info = debug.getinfo(f, "Sl")
+		return create_anchor(true, "SYNTH:" .. info.source, info.currentline, 0)
+	end
+
+	return create_anchor(true, "SYNTH: <debug info disabled>", 0, 0)
 end
 
 ---@param f? (integer | function)

--- a/prelude.alc
+++ b/prelude.alc
@@ -767,7 +767,7 @@ let host-if = lambda_implicit (T : type-omega)
 			""""
 				return U.notail(evaluator.gen_base_operator("#host-if", function(subject, consequent, alternate)
 					return U.notail(terms.typed_term.host_if(subject, consequent, alternate))
-				end))
+				end, "subject", "consequent", "alternate"))
 			:
 			wrapped(forall (subject : host-bool, consequent : T, alternate : T) -> (res : T))
 
@@ -844,7 +844,7 @@ let tuple-desc-concat-indep = lambda_implicit (U : universe)
 			""""
 				return U.notail(evaluator.gen_base_operator("#tuple-desc-concat", function(prefix, suffix)
 					return U.notail(terms.typed_term.tuple_desc_concat_indep(prefix, suffix))
-				end))
+				end, "prefix", "suffix"))
 			:
 			wrapped (forall (pfx : tuple-desc-type(U), sfx : tuple-desc-type(U)) -> (res : tuple-desc-type(U)))
 let tuple-concat = lambda (
@@ -932,7 +932,7 @@ let host-number-fold-indep = lambda_implicit (T : type-omega)
 			""""
 				return U.notail(evaluator.gen_base_operator("#int-fold", function(num, func, acc)
 					return U.notail(terms.typed_term.host_int_fold(num, func, acc))
-				end))
+				end, "num", "func", "acc"))
 			:
 			wrapped((forall (n : host-number, f : (forall (i : host-number, acc : T) -> (resacc : T)), acc : T) -> (res : T)))
 
@@ -1301,7 +1301,7 @@ let core-operative-type =
 			""""
 				return U.notail(evaluator.gen_base_operator("#core-operative-type", function(userdata, handler)
 					return U.notail(terms.typed_term.operative_type_cons(userdata, handler))
-				end))
+				end, "userdata", "handler"))
 			:
 			wrapped(forall (userdata : host-type, handler : operative-handler-type(userdata)) -> (res : host-type))
 
@@ -1312,7 +1312,7 @@ let core-operative = lambda_implicit (userdata : host-type)
 				return U.notail(evaluator.gen_base_operator("#core-operative", function(userdata, handler)
 					-- `handler` is intentionally discarded.
 					return U.notail(terms.typed_term.operative_cons(userdata))
-				end))
+				end, "userdata", "handler"))
 			:
 			wrapped(forall (ud : userdata, handler : operative-handler-type(userdata)) -> (res : core-operative-type(userdata, handler)))
 

--- a/prelude.alc
+++ b/prelude.alc
@@ -64,7 +64,7 @@ let srel = lambda_implicit (U : type-omega+1)
 			""""
 				return U.notail(evaluator.gen_base_operator("#srel", function(target)
 					return U.notail(terms.typed_term.srel_type(target))
-				end))
+				end, "target"))
 			:
 			wrapped (forall ((target : U)) -> (rel : U))
 
@@ -74,7 +74,7 @@ let variance = lambda_implicit (U : type-omega+1)
 			""""
 				return U.notail(evaluator.gen_base_operator("#variance", function(target)
 					return U.notail(terms.typed_term.variance_type(target))
-				end))
+				end, "target"))
 			:
 			wrapped (forall ((target : U)) -> (res : U))
 
@@ -86,7 +86,7 @@ let tuple-desc-type = lambda_implicit (U : universe)
 			""""
 				return U.notail(evaluator.gen_base_operator("#tuple-desc-type", function(a_universe)
 					return U.notail(terms.typed_term.tuple_desc_type(a_universe))
-				end))
+				end, "a_universe"))
 			:
 			wrapped (forall ((a-universe : U)) -> (desc : U))
 
@@ -98,7 +98,7 @@ let _|_ = lambda_implicit (U : type-omega+1)
 			""""
 				return U.notail(evaluator.gen_base_operator("#union", function(left, right)
 					return U.notail(terms.typed_term.union_type(left, right))
-				end))
+				end, "left", "right"))
 			:
 			wrapped (forall (left : U, right : U) -> (union : U))
 
@@ -108,7 +108,7 @@ let _&_ = lambda_implicit (U : type-omega+1)
 			""""
 				return U.notail(evaluator.gen_base_operator("#intersection", function(left, right)
 					return U.notail(terms.typed_term.intersection_type(left, right))
-				end))
+				end, "left", "right"))
 			:
 			wrapped (forall (left : U, right : U) -> (intersection : U))
 
@@ -119,7 +119,7 @@ let covariant = lambda_curry (U : universe, a : U)
 				return U.notail(evaluator.gen_base_operator("#covariant", function(rel)
 					local positive = terms.typed_term.literal(terms.strict_value.host_value(true))
 					return U.notail(terms.typed_term.variance_cons(positive, rel))
-				end))
+				end, "rel"))
 			:
 			wrapped (forall ((rel : srel(a))) -> (covariant-rel : variance(a)))
 
@@ -781,7 +781,7 @@ let tuple-desc-elem-explicit = lambda (U : universe)
 			""""
 				return U.notail(evaluator.gen_base_operator("#tuple-desc-elem-explicit", function(desc, elem)
 					return U.notail(terms.typed_cons(desc, elem))
-				end))
+				end, "desc", "elem"))
 			:
 			wrapped(forall (desc : U-tuple-desc-type, elem : (forall (rest : tuple-type(desc)) -> (next : U))) -> (res : U-tuple-desc-type))
 

--- a/pretty-printer.lua
+++ b/pretty-printer.lua
@@ -308,17 +308,22 @@ end
 
 ---@param f async fun(...):...
 function PrettyPrint:func(f)
-	local d = debug.getinfo(f, "Su")
-	---@type string[]
-	local params = {}
-	for i = 1, d.nparams do
-		params[#params + 1] = debug.getlocal(f, i)
+	if debug then
+		local d = debug.getinfo(f, "Su")
+		---@type string[]
+		local params = {}
+		for i = 1, d.nparams do
+			params[#params + 1] = debug.getlocal(f, i)
+		end
+		if d.isvararg then
+			params[#params + 1] = "..."
+		end
+
+		self[#self + 1] =
+			string.format("%s function(%s): %s:%d", d.what, table.concat(params, ", "), d.source, d.linedefined)
+	else
+		self[#self + 1] = "lua function(<unknown params>): <debug info disabled>"
 	end
-	if d.isvararg then
-		params[#params + 1] = "..."
-	end
-	self[#self + 1] =
-		string.format("%s function(%s): %s:%d", d.what, table.concat(params, ", "), d.source, d.linedefined)
 end
 
 function PrettyPrint_mt:__tostring()

--- a/terms-generators.lua
+++ b/terms-generators.lua
@@ -40,13 +40,24 @@ local function new_self(fn)
 	end
 end
 
+---This attempts to create a traceback only if debug information is actually available
+---@param s string
+---@return string
+local function attempt_traceback(s)
+	if debug then
+		return debug.traceback(s)
+	else
+		return s
+	end
+end
+
 ---@param mt table
 ---@return ValueCheckFn
 local function metatable_equality(mt)
 	if type(mt) ~= "table" then
 		error(
 			"trying to define metatable equality to something that isn't a metatable (possible typo?): "
-				.. debug.traceback(tostring(mt))
+				.. attempt_traceback(tostring(mt))
 		)
 	end
 	return function(val)
@@ -92,7 +103,7 @@ local function validate_params_types(kind, params, params_types)
 		local param_type = params_types[i]
 		if type(param_type) ~= "table" or type(param_type.value_check) ~= "function" then
 			error(
-				debug.traceback(
+				attempt_traceback(
 					"trying to set a parameter type to something that isn't a type, in constructor "
 						.. kind
 						.. ", parameter "
@@ -145,7 +156,7 @@ local function gen_record(self, cons, kind, params_with_types)
 			-- type-check constructor arguments
 			if param_type.value_check(param) ~= true then
 				error(
-					debug.traceback(
+					attempt_traceback(
 						string.format(
 							"wrong argument type passed to constructor %s, parameter %q\nexpected type of parameter %q is: %s\nvalue of parameter %q: (follows)\n%s",
 							kind,
@@ -162,7 +173,7 @@ local function gen_record(self, cons, kind, params_with_types)
 		end
 		if false then
 			-- val["{TRACE}"] = U.bound_here(2)
-			val["{TRACE}"] = debug.traceback("", 2)
+			val["{TRACE}"] = attempt_traceback("", 2)
 			-- val["{TRACE}"] = U.custom_traceback("", "", -1)
 		end
 		val["{ID}"] = U.debug_id()
@@ -239,7 +250,7 @@ local function define_record(self, kind, params_with_types)
 			return t._record[key]
 		end
 		if key ~= "name" then
-			error(debug.traceback("use unwrap instead for: " .. key))
+			error(attempt_traceback("use unwrap instead for: " .. key))
 		end
 		if t._record[key] then
 			return t._record[key]
@@ -355,7 +366,7 @@ local function define_enum(self, name, variants)
 		if key == "{TRACE}" or key == "{ID}" then
 			return t._record[key]
 		end
-		error(debug.traceback("use unwrap instead for: " .. key))
+		error(attempt_traceback("use unwrap instead for: " .. key))
 		if t._record[key] then
 			return t._record[key]
 		end
@@ -474,7 +485,7 @@ local function define_multi_enum(flex, flex_name, fn_replace, fn_specify, fn_uni
 					local param_type = params_types[i]
 					if param_type.value_check(param) ~= true then
 						error(
-							debug.traceback(
+							attempt_traceback(
 								string.format(
 									"wrong argument type passed to constructor %s, parameter %q\nexpected type of parameter %q is: %s\nvalue of parameter %q: (follows)\n%s",
 									param.kind,
@@ -1084,7 +1095,7 @@ local array_type_mt = {
 			local value = select(i, ...)
 			if value_type.value_check(value) ~= true then
 				error(
-					debug.traceback(
+					attempt_traceback(
 						string.format(
 							"wrong value type passed to array creation: expected [%s] of type %s but got %s",
 							s(i),
@@ -1142,7 +1153,7 @@ local function array_new_fn(self, array, n)
 		local value = array[i]
 		if value_type.value_check(value) ~= true then
 			error(
-				debug.traceback(
+				attempt_traceback(
 					string.format(
 						"wrong value type passed to array creation: expected [%s] of type %s but got %s",
 						s(i),
@@ -1208,7 +1219,7 @@ local function gen_array_methods(self, value_type)
 				local value = fn(array[i])
 				if value_type.value_check(value) ~= true then
 					error(
-						debug.traceback(
+						attempt_traceback(
 							string.format(
 								"wrong value type resulting from array mapping: expected [%s] of type %s but got %s",
 								s(i),
@@ -1317,7 +1328,7 @@ local function gen_array_index_fns(self, value_type)
 		end
 		if value_type.value_check(value) ~= true then
 			error(
-				debug.traceback(
+				attempt_traceback(
 					string.format(
 						"wrong value type passed to array index-assignment: expected [%s] of type %s but got %s",
 						s(key),
@@ -1432,7 +1443,7 @@ local function define_array(self, value_type)
 	if type(value_type) ~= "table" or type(value_type.value_check) ~= "function" then
 		error(
 			"trying to set the value type to something that isn't a type (possible typo?): "
-				.. debug.traceback(tostring(value_type))
+				.. attempt_traceback(tostring(value_type))
 		)
 	end
 

--- a/terms.lua
+++ b/terms.lua
@@ -172,7 +172,7 @@ end
 ---@return FlexRuntimeContext
 function FlexRuntimeContext:append(v, name, debuginfo)
 	if debuginfo == nil then
-		error(debug.traceback())
+		error("null debuginfo appended to FlexRuntimeContext")
 	end
 	name = name or debuginfo.name -- ("#r_ctx%d"):format(self.bindings:len() + 1) -- once switchover to debug is complete, no binding should ever enter the environment without debug info and so this name fallback can be removed
 	if name == nil then

--- a/tests/host-if.alc
+++ b/tests/host-if.alc
@@ -3,7 +3,7 @@ let host-if-2 = unwrap
 		""""
 			return U.notail(evaluator.gen_base_operator("#host-if-2", function(result, c2, a1, subject, consequent, alternate)
 				return U.notail(terms.typed_term.host_if(subject, consequent, alternate))
-			end))
+			end, "result", "c2", "a1", "subject", "consequent", "alternate"))
 		:
 		wrapped(forall (
 				result     : host-type,


### PR DESCRIPTION
This lets us run alicorn without debuginfo for use in safe rust contexts (and anywhere else that doesn't have debug exposed for whatever reason). Feather already had the relevant changes done to it's layout.alc file, I confirmed that it now works when passed a fully safe lua context with this change active.