### PR TITLE
test-terms: swap to very simple empty tuple test

### DIFF
--- a/test-terms.lua
+++ b/test-terms.lua
@@ -26,45 +26,4 @@ local function test_empty_tuple()
 	print("test_empty_tuple success")
 end
 
---[[
--- Evaluator cases for levels use non-existent flex_value.level_type and flex_value.level
-function test_levels()
-	print(unanchored_inferrable_term.level0)
-	local suc_term = anchored_inferrable_term(
-		format.anchor_here(),
-		unanchored_inferrable_term.level_suc(
-			anchored_inferrable_term(format.anchor_here(), unanchored_inferrable_term.level0)
-		)
-	)
-	print(suc_term)
-	local test_term = anchored_inferrable_term(
-		format.anchor_here(),
-		unanchored_inferrable_term.level_max(
-			suc_term,
-			anchored_inferrable_term(format.anchor_here(), unanchored_inferrable_term.level0)
-		)
-	)
-	local ok, inferred_type, usages, typed_term = infer(test_term, tc)
-	p(inferred_type)
-	assert(inferred_type:is_level_type())
-	local result = evaluate(typed_term, rc)
-	p(result)
-	assert(result:is_level())
-	assert(result:unwrap_level() == 1)
-	assert(result.level == 1)
-end
-
--- unanchored_inferrable_term.star doesn't exist
-function test_star()
-	local test_term = anchored_inferrable_term(format.anchor_here(), unanchored_inferrable_term.star)
-	local ok, inferred_type, inferred_term = infer(test_term, tc)
-	p(inferred_type, inferred_term)
-	assert(inferred_type.kind == "value_star")
-	local result = evaluate(inferred_term, rc)
-	p(result)
-	assert(result.kind == "value_star")
-	assert(result.level == 0)
-end
-]]
-
 test_empty_tuple()


### PR DESCRIPTION
The existing tests don't work.
Removed ancient metavariable test which was for the old metavariable impl. ~~Commented the level/star tests since the terms they use are missing but not sure if still needed.~~ Removed after confirming these are obsolete.