### PR TITLE
nix-flake-check: pass -L to nix flake check

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
-      - run: nix flake check
+      - run: nix flake check -L
   status:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Logs get cut off otherwise making finding failures slightly more annoying.