### PR TITLE
getopt, runtest: support long options

### DIFF
--- a/getopt.lua
+++ b/getopt.lua
@@ -3,54 +3,73 @@
 
 local _ = require "lua-ext" -- has side-effect of loading string.chars
 
-local function default_unknown(c)
-	error(("Unrecognized option: '-%s'"):format(c))
+---@alias getopt.opt fun(opt_repr: string, keyed_opt_value?: string)
+
+---@type getopt.opt
+local function default_opt_unknown(opt_repr)
+	error(("Unrecognized option: %q"):format(opt_repr))
+end
+
+---@param get_arg_value (fun(): (arg_value: string))
+---@param opt_repr string
+---@param opt_unknown getopt.opt
+---@param unkeyed_opt getopt.opt?
+---@param keyed_opt getopt.opt?
+local function handle_opt(get_arg_value, opt_repr, opt_unknown, unkeyed_opt, keyed_opt)
+	if keyed_opt then
+		local handle_with_value = keyed_opt
+		handle_with_value(opt_repr, get_arg_value())
+	elseif unkeyed_opt then
+		local handle_without_value = unkeyed_opt
+		handle_without_value(opt_repr)
+	else
+		local handle_unknown = opt_unknown
+		handle_unknown(opt_repr)
+	end
 end
 
 ---@param argv string[]
----@param opttab {[string]: fun(string, string?)}
----@return integer
-local function getopt(argv, opttab)
-	local handle_unknown = opttab["?"] or default_unknown
-	local i = 1
+---@param short_opts {[string]: getopt.opt}
+---@return integer argv_index
+local function getopt(argv, short_opts)
+	local opt_unknown = short_opts["?"] or default_opt_unknown
+	local argv_index = 1
 	local argc = #argv
-	while i <= argc do
-		local a = argv[i]
-		if a:sub(1, 1) ~= "-" then
+	while argv_index <= argc do
+		local arg = argv[argv_index]
+		if arg:sub(1, 1) ~= "-" then
 			break
 		end
-		if a == "-" then
+		if arg == "-" then
 			break
 		end
-		if a == "--" then
-			i = i + 1
+		if arg == "--" then
+			argv_index = argv_index + 1
 			break
 		end
-		a = a:sub(2)
-		for j, c in a:chars() do
-			local handle_with_arg = opttab[c .. ":"]
-			local handle_no_arg = opttab[c]
-			if handle_with_arg then
-				if j == #a then
-					handle_with_arg(c, argv[i + 1])
-					i = i + 2
-					goto continue
-				else
-					error(("Value not provided for option: '-%s'"):format(c))
+		local new_arg_wanted = false
+		for arg_index, arg_char in arg:chars(2) do
+			---@cast arg_char string
+			local opt_repr = "-" .. arg_char
+			local function get_arg_value()
+				local next_argv_index = argv_index + 1
+				if arg_index == #arg and next_argv_index <= argc then
+					local arg_value = argv[next_argv_index]
+					new_arg_wanted, argv_index = true, next_argv_index
+					return arg_value
 				end
-			elseif handle_no_arg then
-				handle_no_arg(c)
-			else
-				handle_unknown(c)
+				error(("Value not provided for option: %q"):format(opt_repr))
+			end
+			---@cast arg_index integer
+			---@cast arg_char string
+			handle_opt(get_arg_value, opt_repr, opt_unknown, short_opts[arg_char], short_opts[arg_char .. ":"])
+			if new_arg_wanted then
+				break
 			end
 		end
-		i = i + 1
-		-- load-bearing no-op
-		if true then
-		end
-		::continue::
+		argv_index = argv_index + 1
 	end
-	return i
+	return argv_index
 end
 
 return getopt

--- a/getopt.lua
+++ b/getopt.lua
@@ -30,8 +30,9 @@ end
 
 ---@param argv string[]
 ---@param short_opts {[string]: getopt.opt}
+---@param long_opts {[string]: string|getopt.opt}
 ---@return integer argv_index
-local function getopt(argv, short_opts)
+local function getopt(argv, short_opts, long_opts)
 	local opt_unknown = short_opts["?"] or default_opt_unknown
 	local argv_index = 1
 	local argc = #argv
@@ -47,24 +48,58 @@ local function getopt(argv, short_opts)
 			argv_index = argv_index + 1
 			break
 		end
-		local new_arg_wanted = false
-		for arg_index, arg_char in arg:chars(2) do
-			---@cast arg_char string
-			local opt_repr = "-" .. arg_char
+		if arg:sub(1, 2) == "--" then
+			local arg_equals = arg:find("=", 1, true)
+			local opt_repr = arg
+			if arg_equals then
+				opt_repr = opt_repr:sub(1, arg_equals - 1)
+			end
+			local opt_repr_substr = opt_repr:sub(3)
+			local long_unkeyed_opt = long_opts[opt_repr_substr]
+			local long_keyed_opt = long_opts[opt_repr_substr .. ":"]
+			if type(long_keyed_opt) == "string" then
+				long_keyed_opt = short_opts[long_keyed_opt]
+			end
+			if type(long_unkeyed_opt) == "string" then
+				if long_keyed_opt == nil then
+					long_keyed_opt = short_opts[long_unkeyed_opt .. ":"]
+				end
+				long_unkeyed_opt = short_opts[long_unkeyed_opt]
+			end
 			local function get_arg_value()
+				if arg_equals then
+					return arg:sub(arg_equals + 1)
+				end
 				local next_argv_index = argv_index + 1
-				if arg_index == #arg and next_argv_index <= argc then
+				if next_argv_index <= argc then
 					local arg_value = argv[next_argv_index]
-					new_arg_wanted, argv_index = true, next_argv_index
+					argv_index = next_argv_index
 					return arg_value
 				end
 				error(("Value not provided for option: %q"):format(opt_repr))
 			end
-			---@cast arg_index integer
-			---@cast arg_char string
-			handle_opt(get_arg_value, opt_repr, opt_unknown, short_opts[arg_char], short_opts[arg_char .. ":"])
-			if new_arg_wanted then
-				break
+			handle_opt(get_arg_value, opt_repr, opt_unknown, long_unkeyed_opt, long_keyed_opt)
+		else
+			local new_arg_wanted = false
+			for arg_index, arg_char in arg:chars(2) do
+				---@cast arg_index integer
+				---@cast arg_char string
+				local opt_repr = "-" .. arg_char
+				local function get_arg_value()
+					local next_argv_index = argv_index + 1
+					if arg_index == #arg and next_argv_index <= argc then
+						local arg_value = argv[next_argv_index]
+						new_arg_wanted, argv_index = true, next_argv_index
+						return arg_value
+					end
+					error(("Value not provided for option: %q"):format(opt_repr))
+				end
+				---@cast arg_index integer
+				---@cast arg_char string
+				handle_opt(get_arg_value, opt_repr, opt_unknown, short_opts[arg_char], short_opts[arg_char .. ":"])
+				if new_arg_wanted then
+					break
+				end
 			end
 		end
 		argv_index = argv_index + 1

--- a/getopt.lua
+++ b/getopt.lua
@@ -36,9 +36,7 @@ local function getopt(argv, opttab)
 					i = i + 2
 					goto continue
 				else
-					handle_with_arg(c, a:sub(j + 1))
-					i = i + 1
-					goto continue
+					error(("Value not provided for option: '-%s'"):format(c))
 				end
 			elseif handle_no_arg then
 				handle_no_arg(c)

--- a/lua-ext.lua
+++ b/lua-ext.lua
@@ -19,9 +19,15 @@ local function nextchar(state, control)
 end
 
 ---@param s string
+---@param start? integer
 ---@return function, string, integer
-function string.chars(s)
-	return nextchar, s, 0
+function string.chars(s, start)
+	if start == nil then
+		start = 0
+	else
+		start = start - 1
+	end
+	return nextchar, s, start
 end
 
 -- table.concat

--- a/runtest.lua
+++ b/runtest.lua
@@ -73,7 +73,7 @@ local reload_mode = false
 local test_single = false
 local test_name = ""
 local print_usage = false
-local opttab = {
+local short_opts = {
 	["S"] = function(_)
 		print_src = true
 	end,
@@ -123,11 +123,11 @@ local opttab = {
 		test_single = true
 		test_name = arg
 	end,
-	["?"] = function(c)
+	["?"] = function(_)
 		print_usage = true
 	end,
 }
-local first_operand = getopt(argv, opttab)
+local first_operand = getopt(argv, short_opts)
 
 if print_usage then
 	io.stderr:write(("Usage: %s [-Sfstv] [-p file[,what] | -P file[,what]] [-T test]\n"):format(argv[0]))

--- a/runtest.lua
+++ b/runtest.lua
@@ -74,85 +74,75 @@ local test_single = false
 local test_name = ""
 local print_usage = false
 local short_opts = {
-	["S"] = function(_)
+	["S"] = function(_opt_repr)
 		print_src = true
 	end,
-	["f"] = function(_)
+	["f"] = function(_opt_repr)
 		print_ast = true
 	end,
-	["s"] = function(_)
+	["s"] = function(_opt_repr)
 		print_inferrable = true
 	end,
-	["t"] = function(_)
+	["t"] = function(_opt_repr)
 		print_typed = true
 	end,
-	["v"] = function(_)
+	["v"] = function(_opt_repr)
 		print_evaluated = true
 	end,
-	["r:"] = function(_, arg)
-		if not arg then
-			error("-r requires a file argument")
-		end
+	["r:"] = function(opt_repr, arg)
 		reload_mode = true
 		test_name = arg
 	end,
-	["p:"] = function(_, arg)
-		if not arg then
-			error("-p requires a file argument")
-		end
+	["p:"] = function(opt_repr, arg)
 		profile_run = true
 		profile_flame = false
 		local subargs = U.split_commas(arg)
 		profile_file = subargs[1]
 		profile_what = subargs[2] or "match"
 	end,
-	["P:"] = function(_, arg)
-		if not arg then
-			error("-P requires a file argument")
-		end
+	["P:"] = function(opt_repr, arg)
 		profile_run = true
 		profile_flame = true
 		local subargs = U.split_commas(arg)
 		profile_file = subargs[1]
 		profile_what = subargs[2] or "match"
 	end,
-	["T:"] = function(_, arg)
-		if not arg then
-			error("-T requires a test argument")
-		end
+	["T:"] = function(opt_repr, arg)
 		test_single = true
 		test_name = arg
 	end,
-	["?"] = function(_)
+	["?"] = function(_opt_repr)
 		print_usage = true
 	end,
 }
 local first_operand = getopt(argv, short_opts)
 
 if print_usage then
-	io.stderr:write(("Usage: %s [-Sfstv] [-p file[,what] | -P file[,what]] [-T test]\n"):format(argv[0]))
-	io.stderr:write("  -S  Print the Alicorn source code about to be tested.\n")
-	io.stderr:write("      (mnemonic: Source)\n")
-	io.stderr:write("  -f  Show the AST generated from the source code.\n")
-	io.stderr:write("      (mnemonic: format.read)\n")
-	io.stderr:write("  -s  Show the unchecked term. *\n")
-	io.stderr:write("      (mnemonic: syntax:match)\n")
-	io.stderr:write("  -t  Show the type-checked term. *\n")
-	io.stderr:write("      (mnemonic: typed)\n")
-	io.stderr:write("  -v  Show the evaluated term. *\n")
-	io.stderr:write("      (mnemonic: value)\n")
-	io.stderr:write("      * Some type-checking and evaluation may happen during the course of\n")
-	io.stderr:write("        producing a top-level term, due to the dependent nature of Alicorn.\n")
-	io.stderr:write("  -p  Run a profile over the test and output the trace to a file.\n")
-	io.stderr:write("      (mnemonic: profile)\n")
-	io.stderr:write("      what = match: Profile syntax:match.    [default]\n")
-	io.stderr:write("      what = infer: Profile evaluator.infer.\n")
-	io.stderr:write("      Works best in conjunction with -T.\n")
-	io.stderr:write("  -P  Like -p, but output a flamegraph-compatible trace.\n")
-	io.stderr:write("      (mnemonic: Phlame! :P)\n")
-	io.stderr:write("  -T  Choose a specific test to run.\n")
-	io.stderr:write("      (mnemonic: Test)\n")
-	io.stderr:write("      Without -T, all tests in testlist.json are run.\n")
+	local usage = [=[Usage: %s [-Sfstv] [(-p|-P) <file>[,<what>]] [-T <test>]
+  -S  Print the Alicorn source code about to be tested.
+      (mnemonic: Source)
+  -f  Show the AST generated from the source code.
+      (mnemonic: format.read)
+  -s  Show the unchecked term. *
+      (mnemonic: syntax:match)
+  -t  Show the type-checked term. *
+      (mnemonic: typed)
+  -v  Show the evaluated term. *
+      (mnemonic: value)
+      * Some type-checking and evaluation may happen during the course of
+        producing a top-level term, due to the dependent nature of Alicorn.
+  -p  Run a profile over the test and output the trace to a file.
+      (mnemonic: profile)
+      <what> = match: Profile syntax:match.    [default]
+      <what> = infer: Profile evaluator.infer.
+      Works best in conjunction with -T.
+  -P  Like -p, but output a flamegraph-compatible trace.
+      (mnemonic: Phlame! :P)
+  -T  Choose a specific test to run.
+      (mnemonic: Test)
+      Without -T, all tests in testlist.json are run.
+]=]
+	io.stderr:write(usage:format(argv[0]))
 	os.exit()
 end
 

--- a/runtest.lua
+++ b/runtest.lua
@@ -95,7 +95,6 @@ local short_opts = {
 	end,
 	["p:"] = function(opt_repr, arg)
 		profile_run = true
-		profile_flame = false
 		local subargs = U.split_commas(arg)
 		profile_file = subargs[1]
 		profile_what = subargs[2] or "match"
@@ -115,33 +114,60 @@ local short_opts = {
 		print_usage = true
 	end,
 }
-local long_opts = {}
+local long_opts = {
+	["help"] = "?",
+	["print-src"] = "S",
+	["print-ast"] = "f",
+	["print-inferrable"] = "s",
+	["print-typed"] = "t",
+	["print-evaluated"] = "v",
+	["reload"] = "r",
+	["profile"] = "p",
+	["flamegraph"] = function(_opt_repr)
+		profile_flame = true
+	end,
+	["no-flamegraph"] = function(_opt_repr)
+		profile_flame = false
+	end,
+	["test"] = "T",
+}
 local first_operand = getopt(argv, short_opts, long_opts)
 
 if print_usage then
 	local usage = [=[Usage: %s [-Sfstv] [(-p|-P) <file>[,<what>]] [-T <test>]
-  -S  Print the Alicorn source code about to be tested.
-      (mnemonic: Source)
-  -f  Show the AST generated from the source code.
-      (mnemonic: format.read)
-  -s  Show the unchecked term. *
-      (mnemonic: syntax:match)
-  -t  Show the type-checked term. *
-      (mnemonic: typed)
-  -v  Show the evaluated term. *
-      (mnemonic: value)
-      * Some type-checking and evaluation may happen during the course of
-        producing a top-level term, due to the dependent nature of Alicorn.
-  -p  Run a profile over the test and output the trace to a file.
-      (mnemonic: profile)
-      <what> = match: Profile syntax:match.    [default]
-      <what> = infer: Profile evaluator.infer.
-      Works best in conjunction with -T.
-  -P  Like -p, but output a flamegraph-compatible trace.
-      (mnemonic: Phlame! :P)
-  -T  Choose a specific test to run.
-      (mnemonic: Test)
-      Without -T, all tests in testlist.json are run.
+  -S, --print-source
+          Print the Alicorn source code about to be tested.
+          (mnemonic: Source)
+  -f, --print-ast
+          Show the AST generated from the source code.
+          (mnemonic: format.read)
+  -s, --print-inferrable
+          Show the unchecked term. *
+          (mnemonic: syntax:match)
+  -t, --print-typed
+          Show the type-checked term. *
+          (mnemonic: typed)
+  -v, --print-evaluated
+          Show the evaluated term. *
+          (mnemonic: value)
+
+          * Some type-checking and evaluation may happen during the course of
+          producing a top-level term, due to the dependent nature of Alicorn.
+  -p, --profile <file>[,<what>]
+          Run a profile over the test and output the trace to a file.
+          (mnemonic: profile)
+          what = match: Profile syntax:match.    [default]
+          what = infer: Profile evaluator.infer.
+          Works best in conjunction with -T.
+      --[no-]flamegraph
+          Enable or disable outputting a flamegraph-compatible trace when profiling.
+  -P <file>[,<what>]
+          Like -p, but enable outputting a flamegraph-compatible trace.
+          (mnemonic: Phlame! :P)
+  -T, --test <file>
+          Choose a specific test to run.
+          (mnemonic: Test)
+          Without -T, all tests in testlist.json are run.
 ]=]
 	io.stderr:write(usage:format(argv[0]))
 	os.exit()

--- a/runtest.lua
+++ b/runtest.lua
@@ -50,7 +50,7 @@ if arg then -- puc-rio lua, luajit
 	interpreter_argv = table.move(arg, n + 1, -1, 0, {})
 	argv = table.move(arg, 0, #arg, 0, {})
 elseif process.argv then -- luvit
-	local file_n = getopt(process.argv, { ["?"] = function() end })
+	local file_n = getopt(process.argv, { ["?"] = function() end }, {})
 	interpreter_argv = table.move(process.argv, 0, file_n - 1, 0, {})
 	argv = table.move(process.argv, file_n, #process.argv, 0, {})
 else
@@ -115,7 +115,8 @@ local short_opts = {
 		print_usage = true
 	end,
 }
-local first_operand = getopt(argv, short_opts)
+local long_opts = {}
+local first_operand = getopt(argv, short_opts, long_opts)
 
 if print_usage then
 	local usage = [=[Usage: %s [-Sfstv] [(-p|-P) <file>[,<what>]] [-T <test>]


### PR DESCRIPTION
i would like to be able to introduce options in `runtest.lua`, even just for debugging, without having to come up with really bad short option names for them