### PR TITLE
avoid `alicorn_expressions.host_applicative()`

### DIFF
--- a/base-env.lua
+++ b/base-env.lua
@@ -2036,25 +2036,6 @@ local function dump_context_impl(syntax, env)
 end
 
 local core_operations = {
-	["+"] = exprs.host_applicative(function(a, b)
-		return a + b
-	end, { strict_value.host_number_type, strict_value.host_number_type }, { strict_value.host_number_type }),
-	["-"] = exprs.host_applicative(function(a, b)
-		return a - b
-	end, { strict_value.host_number_type, strict_value.host_number_type }, { strict_value.host_number_type }),
-	["*"] = exprs.host_applicative(function(a, b)
-		return a * b
-	end, { strict_value.host_number_type, strict_value.host_number_type }, { strict_value.host_number_type }),
-	["/"] = exprs.host_applicative(function(a, b)
-		return a / b
-	end, { strict_value.host_number_type, strict_value.host_number_type }, { strict_value.host_number_type }),
-	["%"] = exprs.host_applicative(function(a, b)
-		return a % b
-	end, { strict_value.host_number_type, strict_value.host_number_type }, { strict_value.host_number_type }),
-	neg = exprs.host_applicative(function(a)
-		return -a
-	end, { strict_value.host_number_type }, { strict_value.host_number_type }),
-
 	--["<"] = evaluator.host_applicative(function(args)
 	--  return { variant = (args[1] < args[2]) and 1 or 0, arg = types.unit_val }
 	--end, types.tuple {types.number, types.number}, types.cotuple({types.unit, types.unit})),

--- a/base-env.lua
+++ b/base-env.lua
@@ -2036,13 +2036,6 @@ local function dump_context_impl(syntax, env)
 end
 
 local core_operations = {
-	--["<"] = evaluator.host_applicative(function(args)
-	--  return { variant = (args[1] < args[2]) and 1 or 0, arg = types.unit_val }
-	--end, types.tuple {types.number, types.number}, types.cotuple({types.unit, types.unit})),
-	--["=="] = evaluator.host_applicative(function(args)
-	--  return { variant = (args[1] == args[2]) and 1 or 0, arg = types.unit_val }
-	--end, types.tuple {types.number, types.number}, types.cotuple({types.unit, types.unit})),
-
 	--["do"] = evaluator.host_operative(do_block),
 	let = exprs.host_operative(let_impl, "let_impl"),
 	mk = exprs.host_operative(mk_impl, "mk_impl"),

--- a/prelude.alc
+++ b/prelude.alc
@@ -1593,7 +1593,17 @@ let listtail-reducer =
 
 let host-arith-binop = (host-func-type (a : host-number, b : host-number) -> ((c : host-number)))
 let host-mul = (intrinsic "return function(a, b) return U.notail(a * b) end" : host-arith-binop)
+let host-add = (intrinsic "return function(a, b) return U.notail(a + b) end" : host-arith-binop)
+let host-sub = (intrinsic "return function(a, b) return U.notail(a - b) end" : host-arith-binop)
 let mul = lambda (a : host-number, b : host-number)
 	let (c) = host-mul(a, b)
 	c
+let add = lambda (a : host-number, b : host-number)
+	let (c) = host-add(a, b)
+	c
+let sub = lambda (a : host-number, b : host-number)
+	let (c) = host-sub(a, b)
+	c
 let _*_ = mul
+let _+_ = add
+let _-_ = sub

--- a/prelude.alc
+++ b/prelude.alc
@@ -1622,3 +1622,14 @@ let _/_ = div
 let _%_ = mod
 let _+_ = add
 let _-_ = sub
+
+#### let host-predicate-binop = lambda (T : host-type, U : host-type)
+	host-func-type (a : T, b : U) -> ((c : host-bool))
+#### let host-lt = (intrinsic "return function(a, b) return U.notail(a < b) end" : host-predicate-binop(host-number, host-number))
+#### let host-eq = (intrinsic "return function(a, b) return U.notail(a == b) end" : host-predicate-binop(host-number, host-number))
+#### let lt = lambda (a : host-number, b : host-number)
+	let (c) = host-lt(a, b)
+	c
+#### let eq = lambda (a : host-number, b : host-number)
+	let (c) = host-eq(a, b)
+	c

--- a/prelude.alc
+++ b/prelude.alc
@@ -1592,11 +1592,21 @@ let listtail-reducer =
 #     a
 
 let host-arith-binop = (host-func-type (a : host-number, b : host-number) -> ((c : host-number)))
+let host-arith-urnop = (host-func-type ((a : host-number)) -> ((b : host-number)))
 let host-mul = (intrinsic "return function(a, b) return U.notail(a * b) end" : host-arith-binop)
+let host-div = (intrinsic "return function(a, b) return U.notail(a / b) end" : host-arith-binop)
+let host-mod = (intrinsic "return function(a, b) return U.notail(a % b) end" : host-arith-binop)
 let host-add = (intrinsic "return function(a, b) return U.notail(a + b) end" : host-arith-binop)
 let host-sub = (intrinsic "return function(a, b) return U.notail(a - b) end" : host-arith-binop)
+let host-neg = (intrinsic "return function(a) return U.notail(-a) end" : host-arith-urnop)
 let mul = lambda (a : host-number, b : host-number)
 	let (c) = host-mul(a, b)
+	c
+let div = lambda (a : host-number, b : host-number)
+	let (c) = host-div(a, b)
+	c
+let mod = lambda (a : host-number, b : host-number)
+	let (c) = host-mod(a, b)
 	c
 let add = lambda (a : host-number, b : host-number)
 	let (c) = host-add(a, b)
@@ -1604,6 +1614,11 @@ let add = lambda (a : host-number, b : host-number)
 let sub = lambda (a : host-number, b : host-number)
 	let (c) = host-sub(a, b)
 	c
+let neg = lambda (a : host-number)
+	let (b) = host-neg(a)
+	b
 let _*_ = mul
+let _/_ = div
+let _%_ = mod
 let _+_ = add
 let _-_ = sub


### PR DESCRIPTION
mainly these commits just port the remaining host arithmetic operations. wanted to remove `alicorn_expressions.host_applicative()` entirely but @aiverson said to wait on that.